### PR TITLE
Allow change branches

### DIFF
--- a/project/git.go
+++ b/project/git.go
@@ -96,6 +96,25 @@ func (g gitProject) Download() error {
 			return err
 		}
 	}
+
+	if _, err := os.Stat(g.folder); err == nil {
+		// #nosec
+		var cmd = exec.Command("sh", "-c",
+			"git -C "+g.folder+
+				" checkout"+
+				" -B "+g.Version+
+				" && git -C "+g.folder+
+				" fetch"+
+				" --recurse-submodules"+
+				" --depth 1"+
+				" origin "+g.Version)
+		cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
+		if bts, err := cmd.CombinedOutput(); err != nil {
+			log.Println("git checkout to and fetch of specified branch failed for", g.folder, string(bts))
+			return err
+		}
+	}
 	return nil
 }
 

--- a/project/git_test.go
+++ b/project/git_test.go
@@ -67,6 +67,14 @@ func TestUpdateExistentLocalRepo(t *testing.T) {
 	require.NoError(t, alreadyClonedRepo.Update())
 }
 
+func TestDownloadChangeBranch(t *testing.T) {
+	home := home()
+	repo := project.NewGit(home, "caarlos0/jvm")
+	require.NoError(t, repo.Download())
+	repo = project.NewGit(home, "caarlos0/jvm branch:gh-pages")
+	require.NoError(t, repo.Download())
+}
+
 func TestUpdateNonExistentLocalRepo(t *testing.T) {
 	home := home()
 	repo := project.NewGit(home, "caarlos0/ports")


### PR DESCRIPTION
(copied from original pull 251)

### Description

This change would allow one to have, for example `caarlos0/jvm` in your static plugins list and then later change the branch to `caarlos0/jvm branch:gh-pages` and have the specified branch automatically fetched and checked out rather than having to `antibody purge` that plugin and re-`antibody bundle` it. Closes #250.

### Explanations

The reason I chose to execute the commands with `sh -c` is because that would allow me to only run one `exec.Command()`, rather than one for the `checkout` and one for the `fetch` (but we could just as easily do it that way; I disliked the way I came up with splitting it, which was to have `var cmd1` for checking out and `var cmd2` for fetching).

The reason why everything is separated with `+` instead of `,` is due to how `sh -c` is handled: in my testing, without using `+`, `sh -c` would not execute the entire command as one line; I assume it separated it by the `,` (eg `"sh", "-c", "git -C ", g.folder, "checkout -B <g.Version>", ...` becomes `sh -c git -C <g.folder>; checkout -B <g.Version>; ...`). I read that `go` uses the `,` to separate and add a space between arguments, but it didn't seem to work how I imagined it would when coupled with `sh -c`. This is likely common knowledge to the more advanced `go` programmers, so if there is a preferred or easier way to pass the checking out and fetching to `sh -c`, please let me know and I will make changes.

A note about the `git checkout -B <branch>` command (if you don't already know): this creates `<branch>` and switches to it, much like the `-b` switch, but if the branch already exists, it will move it to the `HEAD` of that branch. If you believe that should not happen (eg, because the branch is dirty due to user changes), we could change it to a `||` statement: `git checkout -b <branch> || git checkout <branch>` which would create and switch to the \<branch> if it doesn't exist, or simply switch to it if it already exists.

There are some things I have not tested yet (and probably won't unless someone deems it necessary): if the checked out branch is behind, does `antibody update` update that branch? I would assume so, but I didn't do that deep of a code dive to find out. Additionally, would `anitbody update` or `antibody bundle` complain if the dir is dirty/diverged/ahead/etc? Does this get handled by the `if` section at [lines 113-116](https://github.com/cole-h/antibody/blob/61efb4a555aab130c5082550557de4fb31ceec7e/project/git.go#L113-L116)? If not, a potential way to address that would be to `git stash <timestamp>` after checking out and before fetching the branch, to account for unstaged and/or uncommitted changes.

After this change, when calling `antibody purge` on a folder, how necessary do you think a branch argument would be — to purge only a specified branch using the same `branch:` syntax? I personally believe this would be unnecessary (because I associate the word "purge" with complete removal), but it might be something worth discussing.

### Disclaimer

This was tested inside of WSL on Arch Linux, so I cannot guarantee it will work on any other setup/distro/toaster.

This is the first time I have touched the `go` language, so I apologize if I have done some things that are not consistent with your expectations of quality. In an attempt to get `make ci` to work, I had to run `goimports` on the `git.go` file, which is why the spacing of `exec.Command()` looks weird (to me). This didn't work, so I manually ran the `make test` command — `go test -failfast -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt ./... -run .` — without the timeout because of WSL's abysmal IO performance.

Similarly, I have never written a test before (ever, not just in `go`), so if there is anything wrong with how I structured my test, guide me to the proper way and I will adjust the code.

&nbsp;

That's all. Thanks!